### PR TITLE
Modernize

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -6,7 +6,7 @@ local waffles = {}
 
 -- Return default sounds if available
 waffles.default_sounds = function(name)
-    if default and default[name] then return default[name]() end
+    if minetest.global_exists("default") and default[name] then return default[name]() end
 end
 
 waffles.setting_or = function(name, default)

--- a/maker.lua
+++ b/maker.lua
@@ -46,6 +46,7 @@ local def_base = {
     description = S("Waffle Maker"),
     drawtype = "mesh",
     tiles = {"waffles_waffle_maker.png"},
+    use_texture_alpha = "clip",
     paramtype = "light",
     sunlight_propagates = true,
     paramtype2 = "facedir",

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,3 @@
 name = waffles
 description = Waffles. Thats it.
+optional_depends = default

--- a/waffle.lua
+++ b/waffle.lua
@@ -14,6 +14,7 @@ minetest.register_node(MODNAME .. ":waffle", {
     drawtype = "mesh",
     mesh = "waffles_waffle.obj",
     tiles = {"waffles_waffle.png"},
+    use_texture_alpha = "clip",
     inventory_image = "waffles_waffle_inv.png",
     wield_image = "waffles_waffle_inv.png",
     paramtype = "light",


### PR DESCRIPTION
Remove annoying warnings:
check for global variable existence
set use_texture_alpha to "clip"

Add default as an optional dependency to guarantee nodes from default were loaded before this mod (if default enabled/available). Module load order in not guaranteed else.