### PR TITLE
Fix names of translation files and textdomain headers

### DIFF
--- a/locale/template.txt
+++ b/locale/template.txt
@@ -1,4 +1,4 @@
-# waffles
+# textdomain: waffles
 # <Language> Translation
 
 Waffle Maker=

--- a/locale/waffles.de.tr
+++ b/locale/waffles.de.tr
@@ -1,4 +1,4 @@
-# waffles
+# textdomain: waffles
 # German Translation
 
 Waffle Maker=Waffeleisen

--- a/locale/waffles.es.tr
+++ b/locale/waffles.es.tr
@@ -1,4 +1,4 @@
-# waffles
+# textdomain: waffles
 # Spanish Translation
 
 Waffle Maker=Wafflera

--- a/locale/waffles.fr.tr
+++ b/locale/waffles.fr.tr
@@ -1,4 +1,4 @@
-# waffles
+# textdomain: waffles
 # French Translation
 
 Waffle Maker=Gaufrier

--- a/locale/waffles.ms.tr
+++ b/locale/waffles.ms.tr
@@ -1,4 +1,4 @@
-# waffles
+# textdomain: waffles
 # Malay Translation
 
 Waffle Maker=Pembakar Wafel


### PR DESCRIPTION
Changes to adhere to https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md#old-translation-file-format